### PR TITLE
fix ignored github init errors and sync command env/args slices

### DIFF
--- a/internal/sync_commands/command.go
+++ b/internal/sync_commands/command.go
@@ -133,8 +133,7 @@ func (c *Command) ExecuteWithData(data CommandTemplateData) (err error) {
 	c.cmdTemplate.Execute(&cmdBuf, data)
 	compiledCmd = cmdBuf.String()
 
-	// compiled args
-	compiledArgs = make([]string, len(c.argsTemplates))
+	compiledArgs = make([]string, 0, len(c.argsTemplates))
 	for _, argTemplate := range c.argsTemplates {
 		argBuf := bytes.Buffer{}
 		argTemplate.Execute(&argBuf, data)
@@ -167,7 +166,6 @@ func (c *Command) ExecuteWithData(data CommandTemplateData) (err error) {
 }
 
 func (c *Command) exec(opts ExecOptions) error {
-	// doing something wrong here, but can't see it so make sure args exclude blank args
 	sanitizedArgs := []string{}
 	opts.ExecLogger.Debug("sanitizing args", "args", opts.Args)
 	for _, arg := range opts.Args {
@@ -283,7 +281,7 @@ func (c *Command) exec(opts ExecOptions) error {
 
 // EnvironmentSlice returns the environment variables as a slice of strings
 func (o *ExecOptions) EnvironmentSlice() []string {
-	env := make([]string, len(o.Environment))
+	env := make([]string, 0, len(o.Environment))
 	for k, v := range o.Environment {
 		env = append(env, fmt.Sprintf("%s=%s", strings.TrimSpace(k), strings.TrimSpace(v)))
 	}

--- a/internal/sync_commands/command_test.go
+++ b/internal/sync_commands/command_test.go
@@ -431,20 +431,11 @@ func TestExecOptions_EnvironmentSlice(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.opts.EnvironmentSlice()
 
-			// The actual implementation has a bug where it creates a slice with len(Environment)
-			// and then appends to it, so the length is 2 * len(Environment)
-			expectedLength := len(tt.expected) * 2
-			if len(tt.expected) == 0 {
-				expectedLength = 0
-			}
-
-			// Check length (accounting for the bug in the implementation)
-			if len(result) != expectedLength {
-				t.Errorf("EnvironmentSlice() length = %d, want %d", len(result), expectedLength)
+			if len(result) != len(tt.expected) {
+				t.Errorf("EnvironmentSlice() length = %d, want %d", len(result), len(tt.expected))
 			}
 
 			// Check that all expected values are present (order may vary due to map iteration)
-			// We need to check for duplicates since the implementation has a bug
 			for _, expected := range tt.expected {
 				found := false
 				for _, actual := range result {

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -71,6 +71,9 @@ func New(opts Options) (v *Validator, err error) {
 		Cluster: opts.Cluster,
 		Client:  v.cfg.Client,
 	})
+	if err != nil {
+		return nil, err
+	}
 	v.sfdpClient = sfdp.NewClient(sfdp.Options{
 		Cluster: opts.Cluster,
 		Client:  v.cfg.Client,


### PR DESCRIPTION
## Summary

`validator.New` assigned `github.NewClient` into `v.githubClient` but never checked the returned error. If client setup fails (unknown client mapping, bad repo URL parsing, regex compile failure, etc.), the code kept going with a nil `githubClient` and would panic on the first GitHub call instead of failing fast with a clear error.

In `sync_commands`, two slice builders were wrong in the same way: they used `make([]T, n)` and then `append`, which leaves `n` zero values at the front. For compiled args that meant extra empty strings before the real arguments (the sanitizer often hid it). For `EnvironmentSlice` those empty strings were passed through to `exec.Command` as `cmd.Env`, which replaces the whole environment. Leading empty entries are invalid and can break what the child process actually sees.

This patch checks the GitHub client error, builds args with length-zero slice plus capacity and append, and builds env the same way. Tests for `EnvironmentSlice` were updated to expect the correct length (they previously encoded the buggy behavior).

made by mooncitydev
