### PR TITLE
[feature] make jito-solana release detection use agave classification

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -136,7 +136,9 @@ func (c *Client) GetLatestClientVersion() (latestVersion *version.Version, err e
 			versionStrings[cluster] = versionsFromReleaseBodyRegex(releases, c.releaseNotesRegexes[cluster])
 		}
 		return c.latestVersionFromClusterVersionStrings(versionStrings)
-	case constants.ClientNameJitoSolana, constants.ClientNameFiredancer:
+	case constants.ClientNameJitoSolana:
+		return c.getLatestJitoSolanaVersion(ctx)
+	case constants.ClientNameFiredancer:
 		releases, _, err := c.client.Repositories.ListReleases(ctx, c.repoOwner, c.repoName, &github.ListOptions{
 			PerPage: 20, // We just need the last few releases
 		})
@@ -144,7 +146,7 @@ func (c *Client) GetLatestClientVersion() (latestVersion *version.Version, err e
 			return nil, fmt.Errorf("failed to get releases: %w", err)
 		}
 		versionStrings := make(map[string][]string)
-		// jito-solana and firedancer flags release cluster in release title prefix
+		// firedancer flags release cluster in release title prefix
 		for _, cluster := range constants.ValidClusterNames {
 			versionStrings[cluster] = versionsFromReleaseTitleRegex(releases, c.releaseTitleRegexes[cluster])
 		}
@@ -154,6 +156,45 @@ func (c *Client) GetLatestClientVersion() (latestVersion *version.Version, err e
 	default:
 		return nil, fmt.Errorf("unsupported client: %s", c.clientName)
 	}
+}
+
+func (c *Client) getLatestJitoSolanaVersion(ctx context.Context) (latestVersion *version.Version, err error) {
+	jitoReleases, _, err := c.client.Repositories.ListReleases(ctx, c.repoOwner, c.repoName, &github.ListOptions{
+		PerPage: 100,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get jito-solana releases: %w", err)
+	}
+
+	agaveOwner, agaveRepo, err := ownerAndRepoFromURL(clientRepoConfigs[constants.ClientNameAgave].URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract agave owner/repo from URL: %w", err)
+	}
+
+	agaveReleases, _, err := c.client.Repositories.ListReleases(ctx, agaveOwner, agaveRepo, &github.ListOptions{
+		PerPage: 100,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get agave releases for jito-solana classification: %w", err)
+	}
+
+	versionStrings := make(map[string][]string)
+	// jito-solana tags are Agave versions with a -jito suffix. Classify the
+	// underlying Agave version from Agave release notes, then map back to the
+	// matching Jito release tag so title prefixes are not required.
+	for _, cluster := range constants.ValidClusterNames {
+		agaveReleaseNotesRegex, err := regexp.Compile(clientRepoConfigs[constants.ClientNameAgave].ReleaseNotesRegexes[cluster])
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile agave release notes regex for jito-solana classification: %w", err)
+		}
+		versionStrings[cluster] = jitoVersionStringsFromAgaveReleaseBodyRegex(
+			jitoReleases,
+			agaveReleases,
+			agaveReleaseNotesRegex,
+		)
+	}
+
+	return c.latestVersionFromClusterVersionStrings(versionStrings)
 }
 
 func (c *Client) getLatestRakuraiVersion(ctx context.Context) (latestVersion *version.Version, err error) {
@@ -506,6 +547,52 @@ func versionsFromReleaseBodyRegex(releases []*github.RepositoryRelease, regex *r
 		}
 	}
 	return versionStrings
+}
+
+func jitoVersionStringsFromAgaveReleaseBodyRegex(jitoReleases []*github.RepositoryRelease, agaveReleases []*github.RepositoryRelease, regex *regexp.Regexp) (versionStrings []string) {
+	agaveVersionKeys := make(map[string]struct{})
+	for _, agaveVersionString := range versionsFromReleaseBodyRegex(agaveReleases, regex) {
+		key, err := versionKey(agaveVersionString)
+		if err != nil {
+			log.Debug("skipping unparsable agave release version", "version", agaveVersionString, "error", err)
+			continue
+		}
+		agaveVersionKeys[key] = struct{}{}
+	}
+
+	for _, release := range jitoReleases {
+		if release.GetPrerelease() {
+			log.Debug("skipping github pre-release", "title", release.GetName(), "tag", release.GetTagName())
+			continue
+		}
+
+		tagName := release.GetTagName()
+		agaveVersionString := jitoVersionSuffixRegex.ReplaceAllString(tagName, "")
+		if agaveVersionString == tagName {
+			continue
+		}
+
+		key, err := versionKey(agaveVersionString)
+		if err != nil {
+			log.Debug("skipping jito-solana release with unparsable agave version", "title", release.GetName(), "tag", tagName, "version", agaveVersionString, "error", err)
+			continue
+		}
+
+		if _, ok := agaveVersionKeys[key]; ok {
+			log.Debug("found matching jito-solana release by agave classification", "title", release.GetName(), "tag", tagName, "agaveVersion", agaveVersionString)
+			versionStrings = append(versionStrings, tagName)
+		}
+	}
+
+	return versionStrings
+}
+
+func versionKey(versionString string) (string, error) {
+	v, err := version.NewVersion(versionString)
+	if err != nil {
+		return "", err
+	}
+	return v.String(), nil
 }
 
 // setOwnerAndRepo extracts owner and repo from a GitHub URL

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -424,6 +424,86 @@ func TestVersionsFromReleaseBodyRegex(t *testing.T) {
 	}
 }
 
+func TestJitoVersionStringsFromAgaveReleaseBodyRegex(t *testing.T) {
+	mainnetRegex := regexp.MustCompile(clientRepoConfigs[constants.ClientNameAgave].ReleaseNotesRegexes[constants.ClusterNameMainnetBeta])
+	testnetRegex := regexp.MustCompile(clientRepoConfigs[constants.ClientNameAgave].ReleaseNotesRegexes[constants.ClusterNameTestnet])
+
+	jitoReleases := []*github.RepositoryRelease{
+		{
+			Name:    github.String("v3.1.14-jito"),
+			TagName: github.String("v3.1.14-jito"),
+		},
+		{
+			Name:    github.String("Testnet - v4.0.0-beta.2-jito"),
+			TagName: github.String("v4.0.0-beta.2-jito"),
+		},
+		{
+			Name:    github.String("v3.0.6-jito.1"),
+			TagName: github.String("v3.0.6-jito.1"),
+		},
+		{
+			Name:       github.String("v3.1.15-jito"),
+			TagName:    github.String("v3.1.15-jito"),
+			Prerelease: github.Bool(true),
+		},
+		{
+			Name:    github.String("unrelated"),
+			TagName: github.String("v3.1.16"),
+		},
+	}
+
+	agaveReleases := []*github.RepositoryRelease{
+		{
+			Body:    github.String("This a stable Mainnet release."),
+			TagName: github.String("v3.1.14"),
+		},
+		{
+			Body:    github.String("This is a Testnet release."),
+			TagName: github.String("v4.0.0-beta.2"),
+		},
+		{
+			Body:    github.String("This is a stable release suitable for use on Mainnet Beta."),
+			TagName: github.String("v3.0.6"),
+		},
+		{
+			Body:    github.String("This is a stable Mainnet release."),
+			TagName: github.String("v3.1.15"),
+		},
+	}
+
+	tests := []struct {
+		name  string
+		regex *regexp.Regexp
+		want  []string
+	}{
+		{
+			name:  "mainnet release matches unprefixed jito title",
+			regex: mainnetRegex,
+			want:  []string{"v3.1.14-jito", "v3.0.6-jito.1"},
+		},
+		{
+			name:  "testnet release matches agave testnet classification",
+			regex: testnetRegex,
+			want:  []string{"v4.0.0-beta.2-jito"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := jitoVersionStringsFromAgaveReleaseBodyRegex(jitoReleases, agaveReleases, tt.regex)
+			if len(got) != len(tt.want) {
+				t.Fatalf("jitoVersionStringsFromAgaveReleaseBodyRegex() returned %d versions, want %d: got %v", len(got), len(tt.want), got)
+			}
+
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("jitoVersionStringsFromAgaveReleaseBodyRegex()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestClientRepoConfigs(t *testing.T) {
 	tests := []struct {
 		clientName string


### PR DESCRIPTION
  Make `jito-solana` release detection independent of release title prefixes.

  Jito releases use Agave validator versions with a `-jito` suffix, but release titles are not always prefixed
  with `Mainnet -` or `Testnet -`. This change classifies the underlying Agave version using Agave release
  notes, then maps matching versions back to Jito release tags.