### PR TITLE
[feature] recognize agave testnet upgrade candidates

### DIFF
--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -424,6 +424,62 @@ func TestVersionsFromReleaseBodyRegex(t *testing.T) {
 	}
 }
 
+func TestAgaveReleaseNotesRegexes(t *testing.T) {
+	mainnetRegex := regexp.MustCompile(clientRepoConfigs[constants.ClientNameAgave].ReleaseNotesRegexes[constants.ClusterNameMainnetBeta])
+	testnetRegex := regexp.MustCompile(clientRepoConfigs[constants.ClientNameAgave].ReleaseNotesRegexes[constants.ClusterNameTestnet])
+
+	releases := []*github.RepositoryRelease{
+		{
+			Body:    github.String("This a stable Mainnet release."),
+			TagName: github.String("v3.1.14"),
+		},
+		{
+			Body:    github.String("This is a Testnet release. It is also recommended for Devnet."),
+			TagName: github.String("v4.0.0-beta.7"),
+		},
+		{
+			Body:    github.String("This is a testnet release."),
+			TagName: github.String("v4.0.0-beta.5"),
+		},
+		{
+			Body:    github.String("This is Mainnet-beta Upgrade Candidate release. It is also recommended for Testnet and Devnet."),
+			TagName: github.String("v4.0.0-rc.0"),
+		},
+	}
+
+	tests := []struct {
+		name  string
+		regex *regexp.Regexp
+		want  []string
+	}{
+		{
+			name:  "mainnet stable excludes testnet and upgrade candidates",
+			regex: mainnetRegex,
+			want:  []string{"v3.1.14"},
+		},
+		{
+			name:  "testnet includes direct and recommended testnet releases",
+			regex: testnetRegex,
+			want:  []string{"v4.0.0-beta.7", "v4.0.0-beta.5", "v4.0.0-rc.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := versionsFromReleaseBodyRegex(releases, tt.regex)
+			if len(got) != len(tt.want) {
+				t.Fatalf("versionsFromReleaseBodyRegex() returned %d versions, want %d: got %v", len(got), len(tt.want), got)
+			}
+
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("versionsFromReleaseBodyRegex()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestJitoVersionStringsFromAgaveReleaseBodyRegex(t *testing.T) {
 	mainnetRegex := regexp.MustCompile(clientRepoConfigs[constants.ClientNameAgave].ReleaseNotesRegexes[constants.ClusterNameMainnetBeta])
 	testnetRegex := regexp.MustCompile(clientRepoConfigs[constants.ClientNameAgave].ReleaseNotesRegexes[constants.ClusterNameTestnet])
@@ -436,6 +492,10 @@ func TestJitoVersionStringsFromAgaveReleaseBodyRegex(t *testing.T) {
 		{
 			Name:    github.String("Testnet - v4.0.0-beta.2-jito"),
 			TagName: github.String("v4.0.0-beta.2-jito"),
+		},
+		{
+			Name:    github.String("Testnet - v4.0.0-rc.0-jito"),
+			TagName: github.String("v4.0.0-rc.0-jito"),
 		},
 		{
 			Name:    github.String("v3.0.6-jito.1"),
@@ -462,6 +522,10 @@ func TestJitoVersionStringsFromAgaveReleaseBodyRegex(t *testing.T) {
 			TagName: github.String("v4.0.0-beta.2"),
 		},
 		{
+			Body:    github.String("This is Mainnet-beta Upgrade Candidate release. It is also recommended for Testnet and Devnet."),
+			TagName: github.String("v4.0.0-rc.0"),
+		},
+		{
 			Body:    github.String("This is a stable release suitable for use on Mainnet Beta."),
 			TagName: github.String("v3.0.6"),
 		},
@@ -484,7 +548,7 @@ func TestJitoVersionStringsFromAgaveReleaseBodyRegex(t *testing.T) {
 		{
 			name:  "testnet release matches agave testnet classification",
 			regex: testnetRegex,
-			want:  []string{"v4.0.0-beta.2-jito"},
+			want:  []string{"v4.0.0-beta.2-jito", "v4.0.0-rc.0-jito"},
 		},
 	}
 

--- a/internal/github/clientrepo.go
+++ b/internal/github/clientrepo.go
@@ -15,7 +15,7 @@ var clientRepoConfigs = map[string]ClientRepoConfig{
 		URL: "https://github.com/anza-xyz/agave",
 		ReleaseNotesRegexes: map[string]string{
 			constants.ClusterNameMainnetBeta: ".*(This is a stable release suitable for use on Mainnet Beta|This (?:is )?a stable Mainnet release).*",
-			constants.ClusterNameTestnet:     ".*This is a Testnet release.*",
+			constants.ClusterNameTestnet:     "(?is).*(This is a testnet release|recommended for testnet).*",
 		},
 	},
 	constants.ClientNameJitoSolana: {

--- a/internal/github/clientrepo_test.go
+++ b/internal/github/clientrepo_test.go
@@ -172,7 +172,7 @@ func TestClientRepoConfigs_RegexPatterns(t *testing.T) {
 			clientName: constants.ClientNameAgave,
 			cluster:    constants.ClusterNameTestnet,
 			regexType:  "ReleaseNotesRegex",
-			regex:      ".*This is a Testnet release.*",
+			regex:      "(?is).*(This is a testnet release|recommended for testnet).*",
 		},
 		{
 			clientName: constants.ClientNameJitoSolana,

--- a/internal/versiondiff/versiondiff_test.go
+++ b/internal/versiondiff/versiondiff_test.go
@@ -149,6 +149,12 @@ func TestVersionDiff_IsUpgrade(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "release candidate upgrade from beta jito tag",
+			from:     "v4.0.0-beta.7-jito",
+			to:       "v4.0.0-rc.0-jito",
+			expected: true,
+		},
+		{
 			name:     "pre-release to release",
 			from:     "1.18.0-beta.1",
 			to:       "1.18.0",
@@ -246,7 +252,6 @@ func TestVersionDiff_IsDowngrade(t *testing.T) {
 		})
 	}
 }
-
 
 func TestVersionDiff_Direction(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
  - Broaden Agave testnet release detection to match lowercase testnet wording and “recommended for Testnet”
  - Keep Agave mainnet matching conservative so upgrade candidates remain testnet-only
  - Add coverage for Jito picking up matching `-jito` RC tags through Agave classification
