### PR TITLE
fix github client init and sync command env and args

### DIFF
--- a/internal/sync_commands/command.go
+++ b/internal/sync_commands/command.go
@@ -134,7 +134,7 @@ func (c *Command) ExecuteWithData(data CommandTemplateData) (err error) {
 	compiledCmd = cmdBuf.String()
 
 	// compiled args
-	compiledArgs = make([]string, len(c.argsTemplates))
+	compiledArgs = make([]string, 0, len(c.argsTemplates))
 	for _, argTemplate := range c.argsTemplates {
 		argBuf := bytes.Buffer{}
 		argTemplate.Execute(&argBuf, data)
@@ -283,7 +283,7 @@ func (c *Command) exec(opts ExecOptions) error {
 
 // EnvironmentSlice returns the environment variables as a slice of strings
 func (o *ExecOptions) EnvironmentSlice() []string {
-	env := make([]string, len(o.Environment))
+	env := make([]string, 0, len(o.Environment))
 	for k, v := range o.Environment {
 		env = append(env, fmt.Sprintf("%s=%s", strings.TrimSpace(k), strings.TrimSpace(v)))
 	}

--- a/internal/sync_commands/command_test.go
+++ b/internal/sync_commands/command_test.go
@@ -431,20 +431,11 @@ func TestExecOptions_EnvironmentSlice(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.opts.EnvironmentSlice()
 
-			// The actual implementation has a bug where it creates a slice with len(Environment)
-			// and then appends to it, so the length is 2 * len(Environment)
-			expectedLength := len(tt.expected) * 2
-			if len(tt.expected) == 0 {
-				expectedLength = 0
-			}
-
-			// Check length (accounting for the bug in the implementation)
-			if len(result) != expectedLength {
-				t.Errorf("EnvironmentSlice() length = %d, want %d", len(result), expectedLength)
+			if len(result) != len(tt.expected) {
+				t.Errorf("EnvironmentSlice() length = %d, want %d", len(result), len(tt.expected))
 			}
 
 			// Check that all expected values are present (order may vary due to map iteration)
-			// We need to check for duplicates since the implementation has a bug
 			for _, expected := range tt.expected {
 				found := false
 				for _, actual := range result {

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -71,6 +71,9 @@ func New(opts Options) (v *Validator, err error) {
 		Cluster: opts.Cluster,
 		Client:  v.cfg.Client,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create github client: %w", err)
+	}
 	v.sfdpClient = sfdp.NewClient(sfdp.Options{
 		Cluster: opts.Cluster,
 		Client:  v.cfg.Client,

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -274,6 +274,33 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestNew_UnknownValidatorClient(t *testing.T) {
+	activeKeypair, _ := solana.NewRandomPrivateKey()
+	passiveKeypair, _ := solana.NewRandomPrivateKey()
+
+	opts := Options{
+		Cluster:    "mainnet-beta",
+		SyncConfig: config.Sync{},
+		ValidatorConfig: config.Validator{
+			Client:            "not-a-real-client-name",
+			RPCURL:            "http://localhost:8899",
+			VersionConstraint: ">= 1.0.0",
+			Identities: config.Identities{
+				ActiveKeyPair:  activeKeypair,
+				PassiveKeyPair: passiveKeypair,
+			},
+		},
+	}
+
+	v, err := New(opts)
+	if err == nil {
+		t.Fatal("New() should fail for unknown validator client")
+	}
+	if v != nil {
+		t.Error("New() should return nil validator on github client error")
+	}
+}
+
 func TestNew_InvalidCommand(t *testing.T) {
 	// Create test keypairs
 	activeKeypair, _ := solana.NewRandomPrivateKey()


### PR DESCRIPTION
hey, noticed a few real issues in the sync path while reading the code.

`validator.New` was ignoring the error from `github.NewClient`, so a bad `validator.client` could still end up with a successful constructor and weird state downstream. it now returns a wrapped error.

`ExecuteWithData` built args with `make(len)` plus `append`, which doubled the slice with empty strings in front. the sanitizer papered over some cases but it is still wrong for anything that cares about arg positions or intentional empty args.

`EnvironmentSlice` had the same `make(len)` + `append` bug, so `cmd.Env` picked up empty leading entries. when `inherit_environment` is false that fully replaces the env for the child, so those entries matter.

tests for `EnvironmentSlice` were expecting the old doubled length; they now assert the correct behavior.