### PR TITLE
[fix] firedancer SFDP constraint mapping to repo tags

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/log"
@@ -258,6 +260,9 @@ func (c *Client) latestVersionFromClusterVersionStrings(versionStrings map[strin
 		if len(sortedTagInfos) == 0 {
 			return nil, fmt.Errorf("no parsable %s versions found for client %s", cluster, c.clientName)
 		}
+		for i := range sortedTagInfos {
+			sortedTagInfos[i].TestnetOnly = cluster == constants.ClusterNameTestnet
+		}
 		latestClusterVersion[cluster] = sortedTagInfos[len(sortedTagInfos)-1].Version
 		for _, tagInfo := range sortedTagInfos {
 			c.cachedTagVersions = append(c.cachedTagVersions, tagInfo.Version)
@@ -430,6 +435,152 @@ func (c *Client) TagNameForVersion(v *version.Version) string {
 	}
 
 	return v.Original()
+}
+
+// ResolveFiredancerSFDPCompliantVersion maps SFDP Firedancer requirements to
+// actual Firedancer repo tags. SFDP may publish compatibility-shaped versions
+// like 0.101.0-beta.40101, while the repo tag is shaped like v0.1001.40101.
+func (c *Client) ResolveFiredancerSFDPCompliantVersion(targetVersion *version.Version, minVersion *version.Version, hasMinVersion bool, maxVersion *version.Version, hasMaxVersion bool) (*version.Version, error) {
+	if c.clientName != constants.ClientNameFiredancer {
+		return nil, fmt.Errorf("firedancer SFDP resolver called for client %s", c.clientName)
+	}
+
+	targetKey, err := firedancerCompatibilityKey(targetVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse firedancer target compatibility key from %s: %w", targetVersion.Original(), err)
+	}
+
+	var minKey int64
+	if hasMinVersion {
+		minKey, err = firedancerCompatibilityKey(minVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse firedancer SFDP min compatibility key from %s: %w", minVersion.Original(), err)
+		}
+	}
+
+	var maxKey int64
+	if hasMaxVersion {
+		maxKey, err = firedancerCompatibilityKey(maxVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse firedancer SFDP max compatibility key from %s: %w", maxVersion.Original(), err)
+		}
+	}
+
+	if firedancerCompatibilityKeySatisfies(targetKey, minKey, hasMinVersion, maxKey, hasMaxVersion) {
+		return targetVersion, nil
+	}
+
+	preferHighestCompatible := hasMaxVersion && targetKey > maxKey
+	selectedVersion, ok, err := c.selectFiredancerTagByCompatibilityKey(minKey, hasMinVersion, maxKey, hasMaxVersion, preferHighestCompatible)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("no firedancer tag in cached release list satisfies SFDP requirement %s", firedancerRequirementString(minVersion, hasMinVersion, maxVersion, hasMaxVersion))
+	}
+
+	return selectedVersion, nil
+}
+
+func (c *Client) selectFiredancerTagByCompatibilityKey(minKey int64, hasMinVersion bool, maxKey int64, hasMaxVersion bool, preferHighestCompatible bool) (*version.Version, bool, error) {
+	candidates := c.cachedTagInfos
+	if len(candidates) == 0 {
+		candidates = make([]tagVersionInfo, 0, len(c.cachedTagVersions))
+		for _, cachedVersion := range c.cachedTagVersions {
+			candidates = append(candidates, tagVersionInfo{
+				TagName: cachedVersion.Original(),
+				Version: cachedVersion,
+			})
+		}
+	}
+
+	var selected tagVersionInfo
+	var selectedKey int64
+	for _, candidate := range candidates {
+		if c.cluster == constants.ClusterNameMainnetBeta && candidate.TestnetOnly {
+			continue
+		}
+
+		candidateKey, err := firedancerCompatibilityKey(candidate.Version)
+		if err != nil {
+			c.logger.Debug("skipping firedancer tag with unparsable compatibility key",
+				"tag", candidate.TagName,
+				"version", candidate.Version.Original(),
+				"error", err,
+			)
+			continue
+		}
+		if !firedancerCompatibilityKeySatisfies(candidateKey, minKey, hasMinVersion, maxKey, hasMaxVersion) {
+			continue
+		}
+
+		if selected.Version == nil {
+			selected = candidate
+			selectedKey = candidateKey
+			continue
+		}
+
+		if preferHighestCompatible {
+			if candidateKey > selectedKey || (candidateKey == selectedKey && candidate.Version.GreaterThan(selected.Version)) {
+				selected = candidate
+				selectedKey = candidateKey
+			}
+			continue
+		}
+
+		if candidateKey < selectedKey || (candidateKey == selectedKey && candidate.Version.GreaterThan(selected.Version)) {
+			selected = candidate
+			selectedKey = candidateKey
+		}
+	}
+
+	if selected.Version == nil {
+		return nil, false, nil
+	}
+	return selected.Version, true, nil
+}
+
+func firedancerCompatibilityKeySatisfies(key int64, minKey int64, hasMinVersion bool, maxKey int64, hasMaxVersion bool) bool {
+	if hasMinVersion && key < minKey {
+		return false
+	}
+	if hasMaxVersion && key > maxKey {
+		return false
+	}
+	return true
+}
+
+func firedancerCompatibilityKey(v *version.Version) (int64, error) {
+	if prerelease := v.Prerelease(); prerelease != "" {
+		parts := strings.Split(prerelease, ".")
+		for i := len(parts) - 1; i >= 0; i-- {
+			key, err := strconv.ParseInt(parts[i], 10, 64)
+			if err == nil {
+				return key, nil
+			}
+		}
+		return 0, fmt.Errorf("pre-release %q has no numeric compatibility component", prerelease)
+	}
+
+	segments := v.Segments()
+	if len(segments) < 3 {
+		return 0, fmt.Errorf("version %q has fewer than three segments", v.Original())
+	}
+	return int64(segments[2]), nil
+}
+
+func firedancerRequirementString(minVersion *version.Version, hasMinVersion bool, maxVersion *version.Version, hasMaxVersion bool) string {
+	requirements := make([]string, 0, 2)
+	if hasMinVersion {
+		requirements = append(requirements, ">= "+minVersion.Original())
+	}
+	if hasMaxVersion {
+		requirements = append(requirements, "<= "+maxVersion.Original())
+	}
+	if len(requirements) == 0 {
+		return "<none>"
+	}
+	return strings.Join(requirements, ",")
 }
 
 func (c *Client) versionSourceURL() string {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -522,6 +522,11 @@ func TestFiredancerVersionStringsByClusterIncludesMainnetSuitableTestnetRelease(
 			Body:    github.String("This is a Testnet release."),
 		},
 		{
+			Name:    github.String("Frankendancer Testnet v0.1001.40101 (Agave v0.101.0-beta.40101)"),
+			TagName: github.String("v0.1001.40101"),
+			Body:    github.String("This is a Testnet release."),
+		},
+		{
 			Name:       github.String("Frankendancer Testnet v0.911.40003"),
 			TagName:    github.String("v0.911.40003"),
 			Body:       github.String(mainnetSuitableNotes),
@@ -531,7 +536,7 @@ func TestFiredancerVersionStringsByClusterIncludesMainnetSuitableTestnetRelease(
 
 	got := client.firedancerVersionStringsByCluster(releases)
 	assertVersionStringsEqual(t, got[constants.ClusterNameMainnetBeta], []string{"v0.822.30114", "v0.909.40001"})
-	assertVersionStringsEqual(t, got[constants.ClusterNameTestnet], []string{"v0.909.40001", "v0.910.40002"})
+	assertVersionStringsEqual(t, got[constants.ClusterNameTestnet], []string{"v0.909.40001", "v0.910.40002", "v0.1001.40101"})
 
 	latestMainnet, err := client.latestVersionFromClusterVersionStrings(got)
 	if err != nil {

--- a/internal/github/clientrepo.go
+++ b/internal/github/clientrepo.go
@@ -42,9 +42,9 @@ var clientRepoConfigs = map[string]ClientRepoConfig{
 		},
 		ReleaseTitleRegexes: map[string]string{
 			// One day this will change from Frankendancer to Firedancer so we match on dancer suffix
-			constants.ClusterNameMainnetBeta: "^(.*)dancer Mainnet v([0-9]+\\.[0-9]+\\.[0-9]+)$",
+			constants.ClusterNameMainnetBeta: "^(.*)dancer Mainnet v([0-9]+\\.[0-9]+\\.[0-9]+)(?:\\b.*)?$",
 			// One day this will change from Frankendancer to Firedancer so we match on dancer suffix
-			constants.ClusterNameTestnet: "^(.*)dancer Testnet v([0-9]+\\.[0-9]+\\.[0-9]+)$",
+			constants.ClusterNameTestnet: "^(.*)dancer Testnet v([0-9]+\\.[0-9]+\\.[0-9]+)(?:\\b.*)?$",
 		},
 	},
 }

--- a/internal/github/clientrepo_test.go
+++ b/internal/github/clientrepo_test.go
@@ -215,7 +215,7 @@ func TestClientRepoConfigs_RegexPatterns(t *testing.T) {
 			clientName: constants.ClientNameFiredancer,
 			cluster:    constants.ClusterNameMainnetBeta,
 			regexType:  "ReleaseTitleRegex",
-			regex:      "^(.*)dancer Mainnet v([0-9]+\\.[0-9]+\\.[0-9]+)$",
+			regex:      "^(.*)dancer Mainnet v([0-9]+\\.[0-9]+\\.[0-9]+)(?:\\b.*)?$",
 		},
 		{
 			clientName: constants.ClientNameFiredancer,
@@ -227,7 +227,7 @@ func TestClientRepoConfigs_RegexPatterns(t *testing.T) {
 			clientName: constants.ClientNameFiredancer,
 			cluster:    constants.ClusterNameTestnet,
 			regexType:  "ReleaseTitleRegex",
-			regex:      "^(.*)dancer Testnet v([0-9]+\\.[0-9]+\\.[0-9]+)$",
+			regex:      "^(.*)dancer Testnet v([0-9]+\\.[0-9]+\\.[0-9]+)(?:\\b.*)?$",
 		},
 	}
 
@@ -253,6 +253,55 @@ func TestClientRepoConfigs_RegexPatterns(t *testing.T) {
 
 			if actualRegex != tt.regex {
 				t.Errorf("%s = %v, want %v", tt.regexType, actualRegex, tt.regex)
+			}
+		})
+	}
+}
+
+func TestFiredancerCompatibilityKey(t *testing.T) {
+	mustVersion := func(s string) *goversion.Version {
+		v, err := goversion.NewVersion(s)
+		if err != nil {
+			t.Fatalf("failed to parse version %q: %v", s, err)
+		}
+		return v
+	}
+
+	tests := []struct {
+		name string
+		in   string
+		want int64
+	}{
+		{
+			name: "repo tag with feature-set patch",
+			in:   "v0.910.40000",
+			want: 40000,
+		},
+		{
+			name: "newer repo tag with feature-set patch",
+			in:   "v0.1001.40101",
+			want: 40101,
+		},
+		{
+			name: "SFDP beta-shaped compatibility version",
+			in:   "0.101.0-beta.40101",
+			want: 40101,
+		},
+		{
+			name: "RPC beta-shaped compatibility version",
+			in:   "0.902.0-beta.40002",
+			want: 40002,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := firedancerCompatibilityKey(mustVersion(tt.in))
+			if err != nil {
+				t.Fatalf("firedancerCompatibilityKey() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("firedancerCompatibilityKey(%q) = %d, want %d", tt.in, got, tt.want)
 			}
 		})
 	}
@@ -432,6 +481,149 @@ func TestNormalizeToTagVersion(t *testing.T) {
 				t.Errorf("NormalizeToTagVersion(%q) = %q, want %q", tt.input, got.String(), tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveFiredancerSFDPCompliantVersion(t *testing.T) {
+	mustVersion := func(s string) *goversion.Version {
+		v, err := goversion.NewVersion(s)
+		if err != nil {
+			t.Fatalf("failed to parse version %q: %v", s, err)
+		}
+		return v
+	}
+
+	clientWithTags := func(tags ...string) *Client {
+		tagInfos := make([]tagVersionInfo, 0, len(tags))
+		tagVersions := make([]*goversion.Version, 0, len(tags))
+		for _, tag := range tags {
+			v := mustVersion(tag)
+			tagInfos = append(tagInfos, tagVersionInfo{
+				TagName: tag,
+				Version: v,
+			})
+			tagVersions = append(tagVersions, v)
+		}
+		return &Client{
+			clientName:        constants.ClientNameFiredancer,
+			cachedTagInfos:    tagInfos,
+			cachedTagVersions: tagVersions,
+			logger:            log.WithPrefix("test"),
+		}
+	}
+
+	tests := []struct {
+		name      string
+		tags      []string
+		target    string
+		min       string
+		hasMin    bool
+		max       string
+		hasMax    bool
+		want      string
+		wantError bool
+	}{
+		{
+			name:   "maps SFDP beta min to matching repo tag",
+			tags:   []string{"v0.910.40000", "v0.1001.40101"},
+			target: "v0.910.40000",
+			min:    "0.101.0-beta.40101",
+			hasMin: true,
+			want:   "v0.1001.40101",
+		},
+		{
+			name:   "keeps target when compatibility key satisfies min",
+			tags:   []string{"v0.910.40000", "v0.1001.40101"},
+			target: "v0.1001.40101",
+			min:    "0.101.0-beta.40101",
+			hasMin: true,
+			want:   "v0.1001.40101",
+		},
+		{
+			name:      "errors when no cached repo tag satisfies min",
+			tags:      []string{"v0.910.40000"},
+			target:    "v0.910.40000",
+			min:       "0.101.0-beta.40101",
+			hasMin:    true,
+			wantError: true,
+		},
+		{
+			name:   "selects highest compatible tag for max bound",
+			tags:   []string{"v0.909.39999", "v0.910.40000", "v0.1001.40101"},
+			target: "v0.1001.40101",
+			max:    "0.910.40000",
+			hasMax: true,
+			want:   "v0.910.40000",
+		},
+		{
+			name:   "uses latest tag when duplicate compatibility keys exist",
+			tags:   []string{"v0.1000.40101", "v0.1001.40101"},
+			target: "v0.910.40000",
+			min:    "0.101.0-beta.40101",
+			hasMin: true,
+			want:   "v0.1001.40101",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var minVersion *goversion.Version
+			if tt.hasMin {
+				minVersion = mustVersion(tt.min)
+			}
+			var maxVersion *goversion.Version
+			if tt.hasMax {
+				maxVersion = mustVersion(tt.max)
+			}
+
+			got, err := clientWithTags(tt.tags...).ResolveFiredancerSFDPCompliantVersion(
+				mustVersion(tt.target),
+				minVersion,
+				tt.hasMin,
+				maxVersion,
+				tt.hasMax,
+			)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("ResolveFiredancerSFDPCompliantVersion() error = %v, wantError %v", err, tt.wantError)
+			}
+			if tt.wantError {
+				return
+			}
+			if got.Original() != tt.want {
+				t.Errorf("ResolveFiredancerSFDPCompliantVersion() = %q, want %q", got.Original(), tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveFiredancerSFDPCompliantVersionDoesNotSelectTestnetOnlyTagForMainnet(t *testing.T) {
+	mustVersion := func(s string) *goversion.Version {
+		v, err := goversion.NewVersion(s)
+		if err != nil {
+			t.Fatalf("failed to parse version %q: %v", s, err)
+		}
+		return v
+	}
+
+	client := &Client{
+		clientName: constants.ClientNameFiredancer,
+		cluster:    constants.ClusterNameMainnetBeta,
+		cachedTagInfos: []tagVersionInfo{
+			{TagName: "v0.910.40000", Version: mustVersion("v0.910.40000")},
+			{TagName: "v0.1001.40101", Version: mustVersion("v0.1001.40101"), TestnetOnly: true},
+		},
+		logger: log.WithPrefix("test"),
+	}
+
+	_, err := client.ResolveFiredancerSFDPCompliantVersion(
+		mustVersion("v0.910.40000"),
+		mustVersion("0.101.0-beta.40101"),
+		true,
+		nil,
+		false,
+	)
+	if err == nil {
+		t.Fatal("ResolveFiredancerSFDPCompliantVersion() should not select a testnet-only tag for mainnet")
 	}
 }
 

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/hashicorp/go-version"
 	"github.com/sol-strategies/solana-validator-version-sync/internal/config"
+	"github.com/sol-strategies/solana-validator-version-sync/internal/constants"
 	"github.com/sol-strategies/solana-validator-version-sync/internal/github"
 	"github.com/sol-strategies/solana-validator-version-sync/internal/rpc"
 	"github.com/sol-strategies/solana-validator-version-sync/internal/sfdp"
@@ -282,6 +283,34 @@ func (v *Validator) getSFDPCompliantVersion(targetVersion *version.Version) (sfd
 	}
 
 	v.logger.Debug("got latest requirements from SFDP", "sfdpRequirements", sfdpRequirements.Constraints.String())
+
+	if constants.NormalizeClientName(v.cfg.Client) == constants.ClientNameFiredancer {
+		sfdpCompliantVersion, err = v.githubClient.ResolveFiredancerSFDPCompliantVersion(
+			targetVersion,
+			sfdpRequirements.MinVersion,
+			sfdpRequirements.HasMinVersion,
+			sfdpRequirements.MaxVersion,
+			sfdpRequirements.HasMaxVersion,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if sfdpCompliantVersion.Equal(targetVersion) {
+			v.logger.Info("target version is within SFDP constraints",
+				"targetVersion", targetVersion.Original(),
+				"sfdpRequirement", sfdpRequirements.Constraints.String(),
+			)
+			return sfdpCompliantVersion, nil
+		}
+
+		v.logger.Warn("target version is not within SFDP constraints - updating to SFDP compliant firedancer tag",
+			"targetVersion", targetVersion.Original(),
+			"sfdpCompliantVersion", sfdpCompliantVersion.Original(),
+			"sfdpRequirement", sfdpRequirements.Constraints.String(),
+		)
+		return sfdpCompliantVersion, nil
+	}
 
 	// target version is within SFDP constraints
 	if sfdpRequirements.Constraints.Check(targetVersion.Core()) {


### PR DESCRIPTION
Fixes Firedancer SFDP compliance handling when the SFDP API returns compatibility-shaped versions like `0.101.0-
  beta.40101` instead of Firedancer repo tags like `v0.1001.40101`