### PR TITLE
[fix] include firedancer testnet prereleases for SFDP resolution

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -159,7 +159,7 @@ func (c *Client) firedancerVersionStringsByCluster(releases []*github.Repository
 	versionStrings := make(map[string][]string)
 	// Firedancer usually flags release cluster in the release title prefix.
 	for _, cluster := range constants.ValidClusterNames {
-		versionStrings[cluster] = versionsFromReleaseTitleRegex(releases, c.releaseTitleRegexes[cluster])
+		versionStrings[cluster] = versionsFromReleaseTitleRegexWithPrerelease(releases, c.releaseTitleRegexes[cluster], cluster == constants.ClusterNameTestnet)
 	}
 
 	// Some Testnet-titled Frankendancer releases are explicitly suitable for
@@ -758,8 +758,12 @@ func (c *Client) NormalizeToTagVersion(v *version.Version) *version.Version {
 
 // versionsFromReleaseTitleRegex gets versions from non-prerelease releases with titles matching the supplied regex
 func versionsFromReleaseTitleRegex(releases []*github.RepositoryRelease, regex *regexp.Regexp) (versionStrings []string) {
+	return versionsFromReleaseTitleRegexWithPrerelease(releases, regex, false)
+}
+
+func versionsFromReleaseTitleRegexWithPrerelease(releases []*github.RepositoryRelease, regex *regexp.Regexp, includePrereleases bool) (versionStrings []string) {
 	for _, release := range releases {
-		if release.GetPrerelease() {
+		if release.GetPrerelease() && !includePrereleases {
 			log.Debug("skipping github pre-release", "title", release.GetName(), "tag", release.GetTagName())
 			continue
 		}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -522,9 +522,10 @@ func TestFiredancerVersionStringsByClusterIncludesMainnetSuitableTestnetRelease(
 			Body:    github.String("This is a Testnet release."),
 		},
 		{
-			Name:    github.String("Frankendancer Testnet v0.1001.40101 (Agave v0.101.0-beta.40101)"),
-			TagName: github.String("v0.1001.40101"),
-			Body:    github.String("This is a Testnet release."),
+			Name:       github.String("Frankendancer Testnet v0.1001.40101"),
+			TagName:    github.String("v0.1001.40101"),
+			Body:       github.String("This is a Testnet release."),
+			Prerelease: github.Bool(true),
 		},
 		{
 			Name:       github.String("Frankendancer Testnet v0.911.40003"),
@@ -536,7 +537,7 @@ func TestFiredancerVersionStringsByClusterIncludesMainnetSuitableTestnetRelease(
 
 	got := client.firedancerVersionStringsByCluster(releases)
 	assertVersionStringsEqual(t, got[constants.ClusterNameMainnetBeta], []string{"v0.822.30114", "v0.909.40001"})
-	assertVersionStringsEqual(t, got[constants.ClusterNameTestnet], []string{"v0.909.40001", "v0.910.40002", "v0.1001.40101"})
+	assertVersionStringsEqual(t, got[constants.ClusterNameTestnet], []string{"v0.909.40001", "v0.910.40002", "v0.1001.40101", "v0.911.40003"})
 
 	latestMainnet, err := client.latestVersionFromClusterVersionStrings(got)
 	if err != nil {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -116,7 +116,7 @@ func (m *Manager) runSyncVersionInterval(intervalDuration time.Duration) {
 	)
 
 	if err != nil {
-		m.logger.Error(msg)
+		m.logger.Error(msg, "error", err)
 	} else {
 		m.logger.Info(msg)
 	}


### PR DESCRIPTION
  Fixes Firedancer testnet SFDP resolution by including GitHub prereleases in Firedancer testnet release discovery.

  `v0.1001.40101` is currently marked as a GitHub prerelease, so it was not being cached as a candidate tag. That
  caused SFDP resolution to fail when trying to map `0.101.0-beta.40101` to the expected Firedancer repo tag.
