### PR TITLE
[test] cover latest Firedancer mainnet release detection

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -159,7 +159,27 @@ func (c *Client) firedancerVersionStringsByCluster(releases []*github.Repository
 	versionStrings := make(map[string][]string)
 	// Firedancer usually flags release cluster in the release title prefix.
 	for _, cluster := range constants.ValidClusterNames {
-		versionStrings[cluster] = versionsFromReleaseTitleRegexWithPrerelease(releases, c.releaseTitleRegexes[cluster], cluster == constants.ClusterNameTestnet)
+		includePrereleases := cluster == constants.ClusterNameTestnet
+		for _, release := range releases {
+			if release.GetPrerelease() && !includePrereleases {
+				c.logger.Debug("skipping firedancer pre-release for cluster classification",
+					"cluster", cluster,
+					"title", release.GetName(),
+					"tag", release.GetTagName(),
+					"prerelease", release.GetPrerelease(),
+				)
+				continue
+			}
+			if c.releaseTitleRegexes[cluster].MatchString(release.GetName()) {
+				c.logger.Debug("classified firedancer release by title",
+					"cluster", cluster,
+					"title", release.GetName(),
+					"tag", release.GetTagName(),
+					"prerelease", release.GetPrerelease(),
+				)
+				versionStrings[cluster] = append(versionStrings[cluster], release.GetTagName())
+			}
+		}
 	}
 
 	// Some Testnet-titled Frankendancer releases are explicitly suitable for
@@ -167,9 +187,21 @@ func (c *Client) firedancerVersionStringsByCluster(releases []*github.Repository
 	testnetTitleRegex := c.releaseTitleRegexes[constants.ClusterNameTestnet]
 	mainnetNotesRegex := c.releaseNotesRegexes[constants.ClusterNameMainnetBeta]
 	if testnetTitleRegex != nil && mainnetNotesRegex != nil {
+		mainnetSuitableTestnetVersions := make([]string, 0)
+		for _, release := range releases {
+			if testnetTitleRegex.MatchString(release.GetName()) && mainnetNotesRegex.MatchString(release.GetBody()) {
+				c.logger.Debug("promoting firedancer testnet release to mainnet by release notes",
+					"cluster", constants.ClusterNameMainnetBeta,
+					"title", release.GetName(),
+					"tag", release.GetTagName(),
+					"prerelease", release.GetPrerelease(),
+				)
+				mainnetSuitableTestnetVersions = append(mainnetSuitableTestnetVersions, release.GetTagName())
+			}
+		}
 		versionStrings[constants.ClusterNameMainnetBeta] = appendUniqueVersionStrings(
 			versionStrings[constants.ClusterNameMainnetBeta],
-			versionsFromReleaseTitleAndBodyRegexWithPrerelease(releases, testnetTitleRegex, mainnetNotesRegex, true)...,
+			mainnetSuitableTestnetVersions...,
 		)
 	}
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -592,6 +592,11 @@ func TestFiredancerVersionStringsByClusterIncludesMainnetSuitableTestnetRelease(
 			Prerelease: github.Bool(true),
 		},
 		{
+			Name:    github.String("Frankendancer Mainnet v0.1005.40100"),
+			TagName: github.String("v0.1005.40100"),
+			Body:    github.String("This is a mainnet ready release."),
+		},
+		{
 			Name:       github.String("Firedancer Testnet v1.0.0"),
 			TagName:    github.String("v1.0.0"),
 			Body:       github.String("This is a Testnet release."),
@@ -600,18 +605,18 @@ func TestFiredancerVersionStringsByClusterIncludesMainnetSuitableTestnetRelease(
 	}
 
 	got := client.firedancerVersionStringsByCluster(releases)
-	assertVersionStringsEqual(t, got[constants.ClusterNameMainnetBeta], []string{"v0.822.30114", "v0.909.40001", "v0.911.40003", "v0.1004.40101"})
+	assertVersionStringsEqual(t, got[constants.ClusterNameMainnetBeta], []string{"v0.822.30114", "v0.1005.40100", "v0.909.40001", "v0.911.40003", "v0.1004.40101"})
 	assertVersionStringsEqual(t, got[constants.ClusterNameTestnet], []string{"v0.909.40001", "v0.910.40002", "v0.1001.40101", "v0.911.40003", "v0.1002.40103", "v0.1004.40101", "v1.0.0"})
 
 	latestMainnet, err := client.latestVersionFromClusterVersionStrings(got)
 	if err != nil {
 		t.Fatalf("latestVersionFromClusterVersionStrings() error = %v", err)
 	}
-	if latestMainnet.Original() != "v0.1004.40101" {
-		t.Errorf("latestVersionFromClusterVersionStrings() = %q, want %q", latestMainnet.Original(), "v0.1004.40101")
+	if latestMainnet.Original() != "v0.1005.40100" {
+		t.Errorf("latestVersionFromClusterVersionStrings() = %q, want %q", latestMainnet.Original(), "v0.1005.40100")
 	}
-	if gotTag := client.TagNameForVersion(latestMainnet); gotTag != "v0.1004.40101" {
-		t.Errorf("TagNameForVersion() = %q, want %q", gotTag, "v0.1004.40101")
+	if gotTag := client.TagNameForVersion(latestMainnet); gotTag != "v0.1005.40100" {
+		t.Errorf("TagNameForVersion() = %q, want %q", gotTag, "v0.1005.40100")
 	}
 
 	testnetClient, err := NewClient(Options{

--- a/internal/github/clientrepo_test.go
+++ b/internal/github/clientrepo_test.go
@@ -1108,6 +1108,7 @@ func TestGetLatestClientVersion_FiredancerIncludesMainnetSuitablePrerelease(t *t
 			}
 
 			body := `[
+				{"name":"Frankendancer Mainnet v0.1005.40100","tag_name":"v0.1005.40100","body":"This is a mainnet ready release.","prerelease":false},
 				{"name":"Frankendancer Mainnet v0.909.40001","tag_name":"v0.909.40001","body":"This is a mainnet release.","prerelease":false},
 				{"name":"Frankendancer Testnet v0.1002.40103","tag_name":"v0.1002.40103","body":"This is a Testnet release.","prerelease":true},
 				{"name":"Frankendancer Testnet v0.1004.40101","tag_name":"v0.1004.40101","body":"This is a Testnet release. It may also be used on mainnet with a small amount of stake in accordance with Anza's guidelines for v4.1.0-rc.1.","prerelease":true}
@@ -1140,11 +1141,11 @@ func TestGetLatestClientVersion_FiredancerIncludesMainnetSuitablePrerelease(t *t
 	if err != nil {
 		t.Fatalf("GetLatestClientVersion() error = %v", err)
 	}
-	if got.Original() != "v0.1004.40101" {
-		t.Fatalf("GetLatestClientVersion() = %q, want %q", got.Original(), "v0.1004.40101")
+	if got.Original() != "v0.1005.40100" {
+		t.Fatalf("GetLatestClientVersion() = %q, want %q", got.Original(), "v0.1005.40100")
 	}
-	if gotTag := client.TagNameForVersion(got); gotTag != "v0.1004.40101" {
-		t.Errorf("TagNameForVersion() = %q, want %q", gotTag, "v0.1004.40101")
+	if gotTag := client.TagNameForVersion(got); gotTag != "v0.1005.40100" {
+		t.Errorf("TagNameForVersion() = %q, want %q", gotTag, "v0.1005.40100")
 	}
 }
 


### PR DESCRIPTION
Adds regression coverage for Firedancer v0.1005.40100 mainnet detection and debug logs showing
  how Firedancer releases are classified, skipped, or promoted from testnet notes.